### PR TITLE
Add Ruby 3.0 to versions in CI workflow

### DIFF
--- a/.github/workflows/y.yml
+++ b/.github/workflows/y.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ruby: [ 2.7, 2.6, 2.5 ]
+        ruby: [ '3.0', 2.7, 2.6, 2.5 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby


### PR DESCRIPTION
Ruby 3.0 is now available and I have made a PR to update `reline` (https://github.com/ruby/reline/pull/238). However, in doing so I was seeing seg faults in the CI for `reline`. Things point towards this gem as being involved and so I thought it to be a good idea to also get this gem running on 3.0 for its workflow actions.